### PR TITLE
🛠 Fix: Typo on the second step

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 This repo serves as the website for the Developer Circles Eldoret Community. 
 
 ## Getting started
-1. Fork the project by clicking the fork button above
+1. Fork the project by clicking the fork button above 
 2. Clone the project by opening your terminal and running: 
 
-```shell
-git clone https://https://github.com/DevCEldoret/devceldoret-frontend.git
+```bash
+https://github.com/DevCEldoret/devceldoret-frontend.git
 ```
 
-3. `cd` into the newly created directory then run 
-```shell 
+3. `cd devceldoret-frontend` into the newly created directory then run 
+```bash 
 npm install
 ```
 4. Finally, run:
-```shell 
+```bash 
 npm start --open
 ```


### PR DESCRIPTION
I have changed the clone URL from https/https://github.com/DevCEldoret/devceldoret-frontend.git